### PR TITLE
adding default `None` values

### DIFF
--- a/src/SlyYTDAPI/ytdapi.py
+++ b/src/SlyYTDAPI/ytdapi.py
@@ -233,7 +233,7 @@ class Video:
     channel_name: str
     tags: list[str]
     is_livestream: bool
-    default_audio_language: str | None
+    default_audio_language: str | None = None
     thumbnails: list[str] | None = None
     localized_title: str | None = None
     localized_description: str | None = None
@@ -254,7 +254,7 @@ class Video:
     comment_count: int | None = None
 
     # part: liveStreamingDetails
-    livestream_details: LivestreamDetails | None
+    livestream_details: LivestreamDetails | None = None
     
     # part: topicDetails
     topic_categories: list[str] | None = None


### PR DESCRIPTION
adding default `None` values to livestream_details and default_audio_language

Otherwise, the field would be missing from response if there isn't a value. 

Very nice `to_dict` implementation, btw, now I feel embarrased about my crude piece of ... code :)